### PR TITLE
Row streaming safety

### DIFF
--- a/lib/ooxl/version.rb
+++ b/lib/ooxl/version.rb
@@ -1,3 +1,3 @@
 class OOXL
-  VERSION = "0.0.1.4.26"
+  VERSION = "0.0.1.5.0"
 end

--- a/lib/ooxl/xl_objects/row.rb
+++ b/lib/ooxl/xl_objects/row.rb
@@ -10,20 +10,18 @@ class OOXL
     end
 
     def [](id)
-      cell = if id.is_a?(String)
-        cells.find { |row| row.id == id}
+      if id.is_a?(String)
+        cell(id)
       else
-        cells[id]
+        cells[id] || BlankCell.new(id)
       end
-      (cell.present?) ? cell : BlankCell.new(id)
     end
 
     def cells
       if @options[:padded_cells]
         unless @cells.blank?
           'A'.upto(@cells.last.column).map do |column_letter|
-            cell = @cells.find { |cell| cell.column == column_letter}
-            (cell.blank?) ? BlankCell.new("#{column_letter}#{id}") : cell
+            cell(column_letter)
           end
         end
       else
@@ -32,8 +30,14 @@ class OOXL
     end
 
     def cell(cell_id)
-      cell_final_id = cell_id[/[A-Z]{1,}\d+/] ? cell_id : "#{cell_id}#{id}"
-      cells.find { |cell| cell.id == cell_final_id}
+      cell_final_id = cell_id[/[A-Z]+\d+/] ? cell_id : "#{cell_id}#{id}"
+      cells_by_id[cell_final_id]
+    end
+
+    def cells_by_id
+      @cells_by_id ||= cells.each_with_object(Hash.new { |_, k| BlankCell.new(k) }) do |cell, result|
+        result[cell.id] = cell
+      end
     end
 
     def each

--- a/lib/ooxl/xl_objects/row.rb
+++ b/lib/ooxl/xl_objects/row.rb
@@ -31,11 +31,11 @@ class OOXL
 
     def cell(cell_id)
       cell_final_id = cell_id[/[A-Z]+\d+/] ? cell_id : "#{cell_id}#{id}"
-      cells_by_id[cell_final_id]
+      cell_id_map[cell_final_id]
     end
 
-    def cells_by_id
-      @cells_by_id ||= cells.each_with_object(Hash.new { |_, k| BlankCell.new(k) }) do |cell, result|
+    def cell_id_map
+      @cell_id_map ||= cells.each_with_object(Hash.new { |_, k| BlankCell.new(k) }) do |cell, result|
         result[cell.id] = cell
       end
     end

--- a/lib/ooxl/xl_objects/row_cache.rb
+++ b/lib/ooxl/xl_objects/row_cache.rb
@@ -4,10 +4,18 @@ class OOXL
 
     attr_accessor :styles
 
+    # built on-demand -- use rows instead
+    attr_reader :row_cache
+
+    # built on-demand -- use fetch_row_by_id instead
+    attr_reader :row_id_map
+
     def initialize(sheet_xml, shared_strings, options = {})
       @shared_strings = shared_strings
       @sheet_xml = sheet_xml
       @options = options
+      @row_cache = []
+      @row_id_map = {}
     end
 
     def [](id)
@@ -41,7 +49,7 @@ class OOXL
 
     private
 
-    def parse_more_rows(&block)
+    def parse_more_rows
       row_nodes.drop(row_cache.count).each do |row_node|
         row = Row.load_from_node(row_node, @shared_strings, @styles, @options)
         row_cache << row
@@ -56,16 +64,6 @@ class OOXL
 
     def row_nodes
       @row_nodes ||= @sheet_xml.xpath('//sheetData/row')
-    end
-
-    # built on-demand -- use rows instead
-    def row_cache
-      @row_cache ||= []
-    end
-
-    # built on-demand -- use fetch_row_by_id instead
-    def row_id_map
-      @row_id_map ||= {}
     end
 
     def fetch_row_by_id(row_id)

--- a/lib/ooxl/xl_objects/row_cache.rb
+++ b/lib/ooxl/xl_objects/row_cache.rb
@@ -88,8 +88,8 @@ class OOXL
           real_rows_yielded += 1
         end
 
-        yield row if block_given?
         yielded_rows << row
+        yield row if block_given?
 
         break if real_rows_yielded == row_cache.count && all_rows_loaded?
       end

--- a/lib/ooxl/xl_objects/row_cache.rb
+++ b/lib/ooxl/xl_objects/row_cache.rb
@@ -1,0 +1,102 @@
+class OOXL
+  class RowCache
+    include Enumerable
+
+    attr_accessor :styles
+
+    def initialize(sheet_xml, shared_strings, options = {})
+      @shared_strings = shared_strings
+      @sheet_xml = sheet_xml
+      @options = options
+    end
+
+    def [](id)
+      fetch_row_by_id(id)
+    end
+
+    alias_method :row, :[]
+
+    def each(&block)
+      if @options[:padded_rows]
+        padded_rows(&block)
+      else
+        rows(&block)
+      end
+    end
+
+    def rows(&block)
+      # track yield count to know if caller broke out of loop
+      rows_yielded = 0
+      row_cache.each do |r|
+        yield r if block_given?
+        rows_yielded += 1
+      end
+
+      if !all_rows_loaded? && rows_yielded == row_cache.count
+        parse_more_rows(&block)
+      end
+
+      row_cache
+    end
+
+    private
+
+    def parse_more_rows(&block)
+      row_nodes.drop(row_cache.count).each do |row_node|
+        row = Row.load_from_node(row_node, @shared_strings, @styles, @options)
+        row_cache << row
+        row_id_map[row.id] = row
+        yield row if block_given?
+      end
+    end
+
+    def all_rows_loaded?
+      row_cache.count == row_nodes.count
+    end
+
+    def row_nodes
+      @row_nodes ||= @sheet_xml.xpath('//sheetData/row')
+    end
+
+    # built on-demand -- use rows instead
+    def row_cache
+      @row_cache ||= []
+    end
+
+    # built on-demand -- use fetch_row_by_id instead
+    def row_id_map
+      @row_id_map ||= {}
+    end
+
+    def fetch_row_by_id(row_id)
+      row_id = row_id.to_s
+      return row_id_map[row_id] if all_rows_loaded? || row_id_map.key?(row_id)
+
+      parse_more_rows do |row|
+        return row if row.id == row_id
+      end
+
+      nil
+    end
+
+    def padded_rows
+      real_rows_yielded = 0
+      yielded_rows = []
+      (1..Float::INFINITY).each do |row_index|
+        row = row(row_index)
+        if row.blank?
+          row = Row.new(id: row_index.to_s, cells: [])
+        else
+          real_rows_yielded += 1
+        end
+
+        yield row if block_given?
+        yielded_rows << row
+
+        break if real_rows_yielded == row_cache.count && all_rows_loaded?
+      end
+      yielded_rows
+    end
+  end
+end
+

--- a/lib/ooxl/xl_objects/sheet.rb
+++ b/lib/ooxl/xl_objects/sheet.rb
@@ -171,7 +171,7 @@ class OOXL
       row_index = cell_ref.gsub(/[^\d:]/, '').split(':').map(&:to_i).first
       row = row(row_index)
       return if row.blank?
-      [row[cell_range].value]
+      [row[cell_ref].value]
     end
 
     def self.load_from_stream(xml_stream, shared_strings)

--- a/lib/ooxl/xl_objects/sheet.rb
+++ b/lib/ooxl/xl_objects/sheet.rb
@@ -1,10 +1,14 @@
 require_relative 'sheet/data_validation'
+require_relative 'row_cache'
+
 class OOXL
   class Sheet
     include OOXL::Util
     include Enumerable
-    attr_reader :columns, :data_validations, :shared_strings
-    attr_accessor :comments, :styles, :defined_names, :name
+
+    attr_reader :columns, :data_validations, :shared_strings, :styles
+    attr_accessor :comments, :defined_names, :name
+    delegate :[], :each, :rows, :row, to: :@row_cache
 
     def initialize(xml, shared_strings, options={})
       @xml = Nokogiri.XML(xml).remove_namespaces!
@@ -12,8 +16,8 @@ class OOXL
       @comments = {}
       @defined_names = {}
       @styles = []
-      @loaded_cache = {}
       @options = options
+      @row_cache = RowCache.new(@xml, @shared_strings, options)
     end
 
     def code_name
@@ -41,82 +45,35 @@ class OOXL
       end
     end
 
-    def [](id)
-      if id.is_a?(String)
-        rows.find { |row| row.id == id}
-      else
-        rows[id]
-      end
-    end
 
-    def row(index, stream: false)
-      if @loaded_cache[:rows] || !stream
-        rows.find { |row| row.id == index.to_s}
-      else
-        found_row = nil
-        rows do |row|
-          if row.id == index.to_s
-            found_row = row
-            break
-          end
-        end
-        found_row
-      end
-    end
-
+    # DEPRECATED: stream is no longer separate
     def stream_row(index)
-      row(index, stream: true)
+      row(index)
     end
 
     # test mode
     def cells_by_column(column_letter)
-      columns = []
-      rows.each do |row|
-        columns << row.cells.find { |cell| to_column_letter(cell.id) == column_letter}
+      rows.map do |row|
+        row.cells.find { |cell| to_column_letter(cell.id) == column_letter}
       end
-      columns
     end
 
     def last_column(row_index=1)
       @last_column ||= {}
       @last_column[row_index] ||= begin
-        cells = stream_row(row_index).try(:cells) 
+        cells = row(row_index).try(:cells) 
         cells.last.column if cells.present?
       end
     end
 
-    def cell(cell_id, stream: false)
+    def cell(cell_id)
       column_letter, row_index = cell_id.partition(/\d+/)
-      current_row = row(row_index, stream: stream)
+      current_row = row(row_index)
       current_row.cell(column_letter) unless current_row.nil?
     end
 
-    def formula(cell_id, stream: false)
-      cell(cell_id, stream: stream).try(:formula)
-    end
-
-    def rows
-      @rows ||= begin
-        all_rows = @xml.xpath('//sheetData/row').map do |row_node|
-          row = Row.load_from_node(row_node, @shared_strings, @styles, @options)
-          yield row if block_given?
-          row
-        end
-        @loaded_cache[:rows] = true
-        all_rows
-      end
-    end
-
-    def each
-      if @options[:padded_rows]
-        last_row_index = rows.last.id.to_i
-        (1.upto(last_row_index)).each do |row_index|
-          row = row(row_index)
-          yield (row.blank?) ? Row.new(id: "#{row_index}", cells: []) : row
-        end
-      else
-        rows  { |row| yield row }
-      end
+    def formula(cell_id)
+      cell(cell_id).try(:formula)
     end
 
     def font(cell_reference)
@@ -126,7 +83,6 @@ class OOXL
     def fill(cell_reference)
       cell(cell_reference).try(:fill)
     end
-
 
     def data_validations
       @data_validations ||= begin
@@ -144,6 +100,11 @@ class OOXL
         # merge validations
         [dvalidations, dvalidations_ext].flatten.compact
       end
+    end
+
+    def styles=(styles)
+      @styles = styles
+      @row_cache.styles = styles
     end
 
     # a shortcut for:
@@ -168,39 +129,50 @@ class OOXL
       if cell_range.include?(":")
         cell_letters = cell_range.gsub(/[\d]/, '').split(':')
         start_index, end_index = cell_range[/[A-Z]{1,}\d+/] ? cell_range.gsub(/[^\d:]/, '').split(':').map(&:to_i) : [1, rows.size]
-        # This will allow values from this pattern
-        # 'SheetName!A1:C3'
-        # The number after the cell letter will be the index
-        # 1 => start_index
-        # 3 => end_index
-        # Expected output would be: [['value', 'value', 'value'], ['value', 'value', 'value'], ['value', 'value', 'value']]
         if cell_letters.uniq.size > 1
-          start_index.upto(end_index).map do  |row_index|
-            (letter_index(cell_letters.first)..letter_index(cell_letters.last)).map do |cell_index|
-                row = fetch_row_by_id(row_index.to_s)
-                next if row.blank?
-
-                cell_letter = letter_equivalent(cell_index)
-                row["#{cell_letter}#{row_index}"].value
-            end
-          end
+          list_values_from_rectangle(cell_letters, start_index, end_index)
         else
-          cell_letter = cell_letters.uniq.first
-          (start_index..end_index).to_a.map do |row_index|
-            row = fetch_row_by_id(row_index.to_s)
-            next if row.blank?
-            row["#{cell_letter}#{row_index}"].value
-          end
+          list_values_from_column(cell_letters.uniq.first, start_index, end_index)
         end
       else
         # when only one value: B2
-        row_index = cell_range.gsub(/[^\d:]/, '').split(':').map(&:to_i).first
-        row = fetch_row_by_id(row_index.to_s)
-        return if row.blank?
-        [row[cell_range].value]
+        list_values_from_cell(cell_range)
       end
     end
     alias_method :list_values_from_formula, :list_values_from_cell_range
+
+    # This will allow values from this pattern
+    # 'SheetName!A1:C3'
+    # The number after the cell letter will be the index
+    # 1 => start_index
+    # 3 => end_index
+    # Expected output would be: [['value', 'value', 'value'], ['value', 'value', 'value'], ['value', 'value', 'value']]
+    def list_values_from_rectangle(cell_letters, start_index, end_index)
+      start_index.upto(end_index).map do |row_index|
+        (letter_index(cell_letters.first)..letter_index(cell_letters.last)).map do |cell_index|
+          row = row(row_index)
+          next if row.blank?
+
+          cell_letter = letter_equivalent(cell_index)
+          row["#{cell_letter}#{row_index}"].value
+        end
+      end
+    end
+
+    def list_values_from_column(column_letter, start_index, end_index)
+      (start_index..end_index).to_a.map do |row_index|
+        row = row(row_index)
+        next if row.blank?
+        row["#{column_letter}#{row_index}"].value
+      end
+    end
+
+    def list_values_from_cell(cell_ref)
+      row_index = cell_ref.gsub(/[^\d:]/, '').split(':').map(&:to_i).first
+      row = row(row_index)
+      return if row.blank?
+      [row[cell_range].value]
+    end
 
     def self.load_from_stream(xml_stream, shared_strings)
       self.new(Nokogiri.XML(xml_stream).remove_namespaces!, shared_strings)
@@ -213,9 +185,6 @@ class OOXL
     end
 
     private
-    def fetch_row_by_id(row_id)
-      rows.find { |row| row.id == row_id.to_s}
-    end
 
     def merged_cells_range
       @merged_cells ||= @xml.xpath('//mergeCells/mergeCell').map do |merged_cell|

--- a/ooxml_excel.gemspec
+++ b/ooxml_excel.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '~> 1'
   spec.add_dependency 'rubyzip', '~> 1.0', '< 2.0.0'
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/ooxl/row_cache_spec.rb
+++ b/spec/ooxl/row_cache_spec.rb
@@ -1,0 +1,121 @@
+require 'spec_helper'
+require 'pry'
+
+describe OOXL::RowCache do
+  let(:second_row_id) { 2 }
+  let(:sheet_xml) do
+    raw = <<~XML
+      <worksheet mc:Ignorable="x14ac">
+        <cols>
+          <col min="1" max="2" width="8.5703125"/>
+          <col min="3" max="3" width="0" hidden="1"/>
+          <col min="4" max="1025" width="8.5703125"/>
+        </cols>
+        <sheetData>
+        <row r="1" spans="1:2" x14ac:dyDescent="0.2" ht="102.33">
+          <c r="A1" s="1" t="s"><f>VLOOKUP($C$5,TABLES!$A$904:$AG$910,AG5,0)</f></c>
+          <c r="B1" s="2" t="s"><v>1</v></c>
+          <c r="C1" s="2" t="s"><v>2</v></c>
+        </row>
+        <row r="#{second_row_id}" spans="1:2" x14ac:dyDescent="0.2">
+          <c r="A2" s="3" t="s"><v>2</v></c>
+          <c r="B2" s="2" t="s"><v>3</v></c>
+          <c r="C3" s="2" t="s"><v>4</v></c>
+          <c r="D3" s="2" t="s"><v>5</v></c>
+        </row>
+        <mergeCells count="1">
+          <mergeCell ref="C1:C3"/>
+        </mergeCells>
+        <dataValidations count="1">
+          <dataValidation type="list" allowBlank="1" showInputMessage="1" showErrorMessage="1" sqref="B6">
+            <formula1>named_range</formula1>
+          </dataValidation>
+        </dataValidations>
+      </worksheet>
+    XML
+
+    Nokogiri.XML(raw).remove_namespaces!
+  end
+
+  let(:row_cache) { OOXL::RowCache.new(sheet_xml, []) }
+
+  before do
+    allow(OOXL::Row).to receive(:load_from_node).and_call_original
+  end
+
+  it "loads the rows" do
+    expect(row_cache.rows.count).to eq(2)
+    expect(OOXL::Row).to have_received(:load_from_node).twice
+    expect(row_cache[2]['B2']).to be_a(OOXL::Cell)
+  end
+
+  describe "#row" do
+    it "loads only as many rows as necessary" do
+      row_cache.row(1)
+      expect(OOXL::Row).to have_received(:load_from_node).once
+    end
+
+    it "loads more rows on subsequent calls" do
+      row_cache.row(1)
+      row_cache.row(2)
+      expect(OOXL::Row).to have_received(:load_from_node).twice
+    end
+  end
+
+  describe "#each" do
+    it "loads only as many rows as necessary" do
+      row_cache.each do |_row|
+        break
+      end
+      expect(OOXL::Row).to have_received(:load_from_node).once
+    end
+
+    it "still loads only the first row when it's requested more times" do
+      row_cache.each do |_row|
+        break
+      end
+
+      row_cache.each do |_row|
+        break
+      end
+
+      row_cache.row(1)
+
+      expect(OOXL::Row).to have_received(:load_from_node).once
+    end
+
+    it "loads more rows on subsequent calls" do
+      row_cache.each do |_row|
+        break
+      end
+
+      row_cache.each do
+        # nothing
+      end
+
+      expect(OOXL::Row).to have_received(:load_from_node).twice
+    end
+
+    it "loads more rows on subsequent calls" do
+      row_cache.each do |_row|
+        break
+      end
+
+      row_cache.each do
+        # nothing
+      end
+
+      expect(OOXL::Row).to have_received(:load_from_node).twice
+    end
+
+    context "padded rows" do
+      let(:second_row_id) { 3 }
+      let(:row_cache) { OOXL::RowCache.new(sheet_xml, [], padded_rows: true) }
+
+      it "fills blanks with empty rows" do
+        ids = row_cache.map { |row| row.id }
+        expect(ids).to eq(['1', '2', '3'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
An issue I've hit a few times is that `@loaded_cache[:rows]` is set to `true` when row enumeration breaks early, meaning subsequent calls will only ever see the rows that have been loaded so far. But I don't want to pre-parse the entire sheet, because frequently what I want is in the top few rows of a multi-MB file.

So I moved row access to a separate RowCache file that knows how to pause and restart. The `streaming` option has been removed because all access is now streaming; I could also change the affected methods to accept `options` and just ignore them, if we need to maintain API compatibility.

Also added `cell_id_map` to the Row class and `row_id_map` to the RowCache class to improve lookup speed at the cost of some memory usage.