### PR TITLE
Final performance tweaks

### DIFF
--- a/lib/ooxl/ooxl.rb
+++ b/lib/ooxl/ooxl.rb
@@ -85,7 +85,7 @@ class OOXL
         case entry.name
         when /xl\/worksheets\/sheet(\d+)?\.xml/
           sheet_id = entry.name.scan(/xl\/worksheets\/sheet(\d+)?\.xml/).flatten.first
-          @sheets[sheet_id] = OOXL::Sheet.new(entry.get_input_stream.read, shared_strings, @options)
+          @sheets[sheet_id] = OOXL::Sheet.new(entry.get_input_stream, shared_strings, @options)
         when /xl\/styles\.xml/
           @styles = OOXL::Styles.load_from_stream(entry.get_input_stream.read)
         when /xl\/comments(\d+)?\.xml/

--- a/lib/ooxl/util.rb
+++ b/lib/ooxl/util.rb
@@ -1,12 +1,13 @@
 class OOXL
   module Util
-    COLUMN_LETTERS = ('A'..'ZZZZ').to_a
-    def letter_equivalent(index)
-      COLUMN_LETTERS.fetch(index)
+    COLUMN_LETTERS = [nil] + ('A'..'ZZZZ').to_a
+
+    def letter_index(col_letter)
+      column_letter_to_number(col_letter) - 1
     end
 
-    def letter_index(letter)
-      COLUMN_LETTERS.index { |c_letter| c_letter == letter}
+    def letter_equivalent(col_index)
+      column_number_to_letter(col_index + 1)
     end
 
     def to_column_letter(reference)
@@ -14,11 +15,15 @@ class OOXL
     end
 
     def uniform_reference(ref)
-      ref.to_s[/[A-Z]/] ? letter_index(ref) + 1 : ref
+      ref.to_s[/[A-Z]/] ? column_letter_to_number(ref) : ref
     end
 
     def node_value_extractor(node)
       node.try(:value)
+    end
+
+    def column_number_to_letter(index)
+      COLUMN_LETTERS.fetch(index)
     end
 
     def column_letter_to_number(column_letter)

--- a/lib/ooxl/version.rb
+++ b/lib/ooxl/version.rb
@@ -1,3 +1,3 @@
 class OOXL
-  VERSION = "0.0.1.5.0"
+  VERSION = "0.0.1.5.1"
 end

--- a/lib/ooxl/xl_objects/row.rb
+++ b/lib/ooxl/xl_objects/row.rb
@@ -45,11 +45,15 @@ class OOXL
     end
 
     def self.load_from_node(row_node, shared_strings, styles, options)
-      new(id: row_node.attributes["r"].try(:value),
+      new(id: extract_id(row_node),
           spans: row_node.attributes["spans"].try(:value),
           height: row_node.attributes["ht"].try(:value),
           cells: row_node.xpath('c').map {  |cell_node| OOXL::Cell.load_from_node(cell_node, shared_strings, styles)},
           options: options )
+    end
+
+    def self.extract_id(row_node)
+      row_node.attributes["r"].try(:value)
     end
   end
 end

--- a/lib/ooxl/xl_objects/row_cache.rb
+++ b/lib/ooxl/xl_objects/row_cache.rb
@@ -47,6 +47,18 @@ class OOXL
       row_cache
     end
 
+    def row_range(start_index, end_index)
+      return enum_for(:row_range, start_index, end_index) unless block_given?
+
+      rows do |row|
+        row_id = row.id.to_i
+        next if row_id < start_index
+        break if row_id > end_index
+
+        yield row
+      end
+    end
+
     private
 
     def parse_more_rows

--- a/lib/ooxl/xl_objects/sheet.rb
+++ b/lib/ooxl/xl_objects/sheet.rb
@@ -11,12 +11,13 @@ class OOXL
     delegate :[], :each, :rows, :row, to: :row_cache
 
     def initialize(xml_stream, shared_strings, options={})
-      @xml_stream = xml_stream
       @shared_strings = shared_strings
       @comments = {}
       @defined_names = {}
       @styles = []
       @options = options
+      @xml = Nokogiri.XML(xml_stream).remove_namespaces!
+      @row_cache = RowCache.new(@xml, @shared_strings, @options)
     end
 
     def code_name
@@ -183,6 +184,8 @@ class OOXL
 
     private
 
+    attr_reader :xml, :row_cache
+
     def merged_cells
       @merged_cells ||= xml.xpath('//mergeCells/mergeCell').map do |merged_cell|
         # <mergeCell ref="Q381:R381"/>
@@ -192,14 +195,6 @@ class OOXL
         end_column_letter, end_index = end_reference.partition(/\d+/)
         [(start_column_letter..end_column_letter), (start_index..end_index)]
       end.to_h
-    end
-
-    def xml
-      @xml ||= Nokogiri.XML(@xml_stream).remove_namespaces!
-    end
-
-    def row_cache
-      @row_cache ||= RowCache.new(xml, @shared_strings, @options)
     end
   end
 end

--- a/lib/ooxl/xl_objects/sheet.rb
+++ b/lib/ooxl/xl_objects/sheet.rb
@@ -148,22 +148,20 @@ class OOXL
     # 3 => end_index
     # Expected output would be: [['value', 'value', 'value'], ['value', 'value', 'value'], ['value', 'value', 'value']]
     def list_values_from_rectangle(cell_letters, start_index, end_index)
-      start_index.upto(end_index).map do |row_index|
-        (letter_index(cell_letters.first)..letter_index(cell_letters.last)).map do |cell_index|
-          row = row(row_index)
-          next if row.blank?
+      start_cell = letter_index(cell_letters.first)
+      end_cell = letter_index(cell_letters.last)
+      @row_cache.row_range(start_index, end_index).map do |row|
+        (start_cell..end_cell).map do |cell_index|
 
           cell_letter = letter_equivalent(cell_index)
-          row["#{cell_letter}#{row_index}"].value
+          row["#{cell_letter}#{row.id}"].value
         end
       end
     end
 
     def list_values_from_column(column_letter, start_index, end_index)
-      (start_index..end_index).to_a.map do |row_index|
-        row = row(row_index)
-        next if row.blank?
-        row["#{column_letter}#{row_index}"].value
+      @row_cache.row_range(start_index, end_index).map do |row|
+        row["#{column_letter}#{row.id}"].value
       end
     end
 

--- a/lib/ooxl/xl_objects/sheet.rb
+++ b/lib/ooxl/xl_objects/sheet.rb
@@ -148,13 +148,12 @@ class OOXL
     # 3 => end_index
     # Expected output would be: [['value', 'value', 'value'], ['value', 'value', 'value'], ['value', 'value', 'value']]
     def list_values_from_rectangle(cell_letters, start_index, end_index)
-      start_cell = letter_index(cell_letters.first)
-      end_cell = letter_index(cell_letters.last)
+      start_col = column_letter_to_number(cell_letters.first)
+      end_col = column_letter_to_number(cell_letters.last)
       @row_cache.row_range(start_index, end_index).map do |row|
-        (start_cell..end_cell).map do |cell_index|
-
-          cell_letter = letter_equivalent(cell_index)
-          row["#{cell_letter}#{row.id}"].value
+        (start_col..end_col).map do |col_index|
+          col_letter = column_number_to_letter(col_index)
+          row["#{col_letter}#{row.id}"].value
         end
       end
     end

--- a/lib/ooxl/xl_objects/sheet.rb
+++ b/lib/ooxl/xl_objects/sheet.rb
@@ -128,7 +128,7 @@ class OOXL
       # cell_range values separated by comma
       if cell_range.include?(":")
         cell_letters = cell_range.gsub(/[\d]/, '').split(':')
-        start_index, end_index = cell_range[/[A-Z]{1,}\d+/] ? cell_range.gsub(/[^\d:]/, '').split(':').map(&:to_i) : [1, rows.size]
+        start_index, end_index = cell_range[/[A-Z]{1,}\d+/] ? cell_range.gsub(/[^\d:]/, '').split(':').map(&:to_i) : [1, @row_cache.max_row_index]
         if cell_letters.uniq.size > 1
           list_values_from_rectangle(cell_letters, start_index, end_index)
         else

--- a/lib/ooxl/xl_objects/sheet.rb
+++ b/lib/ooxl/xl_objects/sheet.rb
@@ -10,14 +10,14 @@ class OOXL
     attr_accessor :comments, :defined_names, :name
     delegate :[], :each, :rows, :row, to: :@row_cache
 
-    def initialize(xml_stream, shared_strings, options={})
+    def initialize(xml, shared_strings, options={})
+      @xml = Nokogiri.XML(xml).remove_namespaces!
       @shared_strings = shared_strings
       @comments = {}
       @defined_names = {}
       @styles = []
       @options = options
-      @xml = Nokogiri.XML(xml_stream).remove_namespaces!
-      @row_cache = RowCache.new(@xml, @shared_strings, @options)
+      @row_cache = RowCache.new(@xml, @shared_strings, options)
     end
 
     def code_name


### PR DESCRIPTION
- `row_range` isn't optimal in all cases (e.g. when requesting a small range with high offset, like [999..1000]), but those are likely not as common as iterating from the top minus a small header offset (more like [3..8]).
- Using `rows.size` forced parsing all rows to find the max column length. Delegating it to the unparsed `row_nodes` is equivalent and faster, but parsing only the id of the last row is slightly more correct (I haven't seen row gaps, but they're theoretically possible).
- Replaced implementation of `letter_index` with the direct version.

I tried a few other things like lazily loading sheets, but somehow that made things considerably slower. And a few other things that did seem promising, but gains too small to justify the additional complexity.