### PR TITLE
Update Rubyzip to 1.3.0

### DIFF
--- a/lib/ooxl/version.rb
+++ b/lib/ooxl/version.rb
@@ -1,3 +1,3 @@
 class OOXL
-  VERSION = "0.0.1.5.1"
+  VERSION = "0.0.1.5.2"
 end

--- a/ooxml_excel.gemspec
+++ b/ooxml_excel.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency 'activesupport'
   spec.add_dependency 'nokogiri', '~> 1'
-  spec.add_dependency 'rubyzip', '~> 1.0', '< 2.0.0'
+  spec.add_dependency 'rubyzip', '~> 1.3.0', '< 2.0.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Update Rubyzip version to 1.3.0 due to https://nvd.nist.gov/vuln/detail/CVE-2019-16892

prime: @halcjames 