### PR TITLE
Fix sheet indexing

### DIFF
--- a/lib/ooxl/ooxl.rb
+++ b/lib/ooxl/ooxl.rb
@@ -33,9 +33,11 @@ class OOXL
   end
 
   def sheet(sheet_name)
-    sheet_index = @workbook.sheets.index { |sheet| sheet[:name] == sheet_name}
-    raise "No #{sheet_name} in workbook." if sheet_index.nil?
-    sheet = @sheets.fetch((sheet_index+1).to_s)
+    sheet_meta = @workbook.sheets.find { |sheet| sheet[:name] == sheet_name }
+    raise "No #{sheet_name} in workbook." if sheet_meta.nil?
+
+    sheet_index = sheet_meta[:sheet_id]
+    sheet = @sheets.fetch(sheet_index)
 
     # shared variables
     sheet.name = sheet_name
@@ -73,8 +75,7 @@ class OOXL
   end
 
   def fetch_comments(sheet_index)
-    final_sheet_index = sheet_index+1
-    relationship = @relationships[final_sheet_index.to_s]
+    relationship = @relationships[sheet_index]
     @comments[relationship.comment_id] if relationship.present?
   end
 

--- a/lib/ooxl/version.rb
+++ b/lib/ooxl/version.rb
@@ -1,3 +1,3 @@
 class OOXL
-  VERSION = "0.0.1.5.2"
+  VERSION = "0.0.1.5.3"
 end


### PR DESCRIPTION
Sometimes `ooxl.sheet('Sheet Name')` returns the wrong sheet. I think it's related to `veryHidden` sheets messing up the indexing. Anyway, this appears to fix it.