### PR TITLE
In-memory sheets and fixed sheet ids again

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "ooxml_excel"
+require "./lib/ooxl"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "ooxml_excel"
 # require "pry"
 # Pry.start
 
-require "irb"
-IRB.start
+require "pry"
+Pry.start

--- a/lib/ooxl/version.rb
+++ b/lib/ooxl/version.rb
@@ -1,3 +1,3 @@
 class OOXL
-  VERSION = "0.0.1.5.3"
+  VERSION = "0.0.1.5.4"
 end

--- a/lib/ooxl/xl_objects/relationships.rb
+++ b/lib/ooxl/xl_objects/relationships.rb
@@ -1,29 +1,41 @@
 class OOXL
   class Relationships
     SUPPORTED_TYPES = ['http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments']
+
     def initialize(relationships_node)
-      @types = {}
+      @relationships = []
       parse_relationships(relationships_node)
     end
 
     def comment_id
-      @types['comments']
+      comment_target = by_type('comments').first
+      comment_target && extract_file_reference(comment_target)
+    end
+
+    def [](id)
+      @relationships.find { |rel| rel.id == id }&.target
+    end
+
+    def by_type(type)
+      @relationships.select { |rel| rel.type == type }.map(&:target)
     end
 
     private
+
     def parse_relationships(relationships_node)
       relationships_node = Nokogiri.XML(relationships_node).remove_namespaces!
       relationships_node.xpath('//Relationship').each do |relationship_node|
         relationship_type = relationship_node.attributes["Type"].value
         target = relationship_node.attributes["Target"].value
-        if supported_type?(relationship_type)
-          @types[extract_type(relationship_type)] = extract_file_reference(target)
-        end
+        id = extract_number(relationship_node.attributes["Id"].value)
+        type = extract_type(relationship_type)
+        target = relationship_node.attributes["Target"].value
+        @relationships << Relationship.new(id, type, target)
       end
     end
 
-    def supported_type?(type)
-      SUPPORTED_TYPES.include?(type)
+    def extract_number(str)
+      str.scan(/(\d+)/).flatten.first
     end
 
     def extract_type(type)
@@ -34,6 +46,7 @@ class OOXL
       file.scan(/(\d+)\.[\w]/).flatten.first
     end
 
+    Relationship = Struct.new(:id, :type, :target)
   end
 end
 

--- a/spec/ooxl/ooxl_spec.rb
+++ b/spec/ooxl/ooxl_spec.rb
@@ -63,5 +63,22 @@ describe OOXL do
     expect(fill.bg_color).to eq "FFFF6600"
     expect(fill.fg_color).to eq "FFFF3333"
   end
-  # will add on the next update
+
+  context "loading from stream" do
+    let(:ooxml) { OOXL.parse(File.open('spec/ooxl/resources/test.xlsx')) }
+
+    it 'loads' do
+      # sanity check -- if it parsed the sheets, we know it loaded successfully
+      expect(ooxml.sheets).to eq ['Sheet1', 'Sheet2', 'Hidden']
+    end
+  end
+
+  context "loading from string contents" do
+    let(:ooxml) { OOXL.parse(File.read('spec/ooxl/resources/test.xlsx')) }
+
+    it 'loads' do
+      # sanity check -- if it parsed the sheets, we know it loaded successfully
+      expect(ooxml.sheets).to eq ['Sheet1', 'Sheet2', 'Hidden']
+    end
+  end
 end


### PR DESCRIPTION
Two commits for rebase:
- Support for loading from stream or string in memory; sometimes it's inconvenient to create a file and ensure that it ultimately gets unlinked. Should be backwards-compatible.
- Fix the sheet id lookup again. My last fix looked right but actually broken a few cases; this one works for all files I could find, including some that worked in 0.0.1.5.1 and some that worked in 0.0.1.5.3.