### PR TITLE
Correctly parse all accepted comment xml structures

### DIFF
--- a/lib/ooxl/version.rb
+++ b/lib/ooxl/version.rb
@@ -1,3 +1,3 @@
 class OOXL
-  VERSION = "0.0.1.5.5"
+  VERSION = "0.0.1.5.6"
 end

--- a/lib/ooxl/xl_objects/comments.rb
+++ b/lib/ooxl/xl_objects/comments.rb
@@ -14,7 +14,7 @@ class OOXL
       comment_xml =Nokogiri.XML(comment_xml).remove_namespaces!
 
       comments = comment_xml.xpath("//comments/commentList/comment").map do |comment_node|
-        comment_text_node = comment_node.xpath('./text/r/t')
+        comment_text_node = comment_node.xpath('./text/r/t').presence || comment_node.xpath('./text/t')
 
         value = if comment_text_node.is_a?(Array)
           comment_text_node.map { |comment_text_node| comment_text_node.text }.join('')

--- a/spec/ooxl/resources/comment_sheet_1.xml
+++ b/spec/ooxl/resources/comment_sheet_1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <authors>
+    <author/>
+  </authors>
+  <commentList>
+    <comment ref="A4" authorId="0">
+      <text>
+        <t>Badjoras</t>
+      </text>
+    </comment>
+  </commentList>
+</comments>

--- a/spec/ooxl/resources/comment_sheet_2.xml
+++ b/spec/ooxl/resources/comment_sheet_2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <authors>
+    <author/>
+  </authors>
+  <commentList>
+    <comment ref="A4" authorId="0">
+      <text>
+        <r>
+          <t>Badjoras</t>
+        </r>
+      </text>
+    </comment>
+  </commentList>
+</comments>

--- a/spec/ooxl/xl_objects/comments_spec.rb
+++ b/spec/ooxl/xl_objects/comments_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe OOXL::Comments do
+  let(:comment_sheet_1) { "spec/ooxl/resources/comment_sheet_1.xml" }
+  let(:comment_sheet_2) { "spec/ooxl/resources/comment_sheet_2.xml" }
+
+  context 'when parsing comments sheets' do
+    it 'correctly parses comments in the format text/t' do
+      comments = described_class.load_from_stream(File.read(comment_sheet_1))
+      expect(comments.comments.values.all?(&:blank?)).to be_falsey
+    end
+
+    it 'correctly parses comments in the format text/r/t' do
+      comments = described_class.load_from_stream(File.read(comment_sheet_2))
+      expect(comments.comments.values.all?(&:blank?)).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
### Context

The xlsx format supports comment xml files with the following structures: 
``` xml
<?xml version="1.0" encoding="UTF-8"?>
<comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
  <authors/>
  <commentList>
    <comment ref="..." authorId="...">
      <text>
        <t>...</t>
      </text>
    </comment>
  </commentList>
</comments>
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
  <authors/>
  <commentList>
    <comment ref="..." authorId="...">
      <text>
        <r>
          <t>...</t>
        </r>
      </text>
    </comment>
  </commentList>
</comments>
```

However this library only supports the latter format unlike other popular Ruby libraries like [Roo](https://github.com/roo-rb/roo/blob/5339d3aee8f217528eb4f5ba39065705c19ebcdd/lib/roo/excelx/comments.rb#L16).

### Solution
Support both formats.

co-authored-by: @Tartee
co-authored-by: @ana-c-santos