### PR TITLE
Fix ruby version mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
           matrix:
             parameters:
               ruby_version:
+                - 3.2.7
                 - 3.3.8
                 - 3.4.1
 
@@ -24,7 +25,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "ooxml_excel.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "ooxl.gemspec" }}-{{ checksum "Gemfile" }}
             - v1-gems-ruby-<< parameters.ruby_version >>-
       - run:
           name: Install Gems
@@ -35,7 +36,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "ooxml_excel.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "ooxl.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Add `allowed_push_host` to gemspec metadata.
 - Update CircleCI config to add changelog check.
+- Rename gemspec from `ooxml_excel.gemspec` to `ooxl.gemspec`.
+- Lower required Ruby version from `>= 3.3` to `>= 3.2` to match release environment.
 
 ## 0.1.0 - 2026-03-23
 - Parse Excel spreadsheets (`.xlsx`, `.xlsm`) from file paths, strings, and IO objects.

--- a/ooxl.gemspec
+++ b/ooxl.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Parse Excel spreadsheets with a simple API. Read cell values, formulas, styles, comments, data validations, named ranges, and merged cells from xlsx and xlsm files. Supports streaming from strings and IO objects with lazy row loading for large files.}
   spec.homepage      = "https://github.com/salsify/ooxl"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 3.3"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.metadata = {
     "source_code_uri"   => "https://github.com/salsify/ooxl",


### PR DESCRIPTION
## Description

Fix the Ruby version difference between the release tool and what gem requires. 

## Checklist

- [x] Tests added or updated
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Documentation updated (if applicable)
- [x] All tests pass (`bundle exec rake spec`)
