### PR TITLE
Upgrade rubyzip to v3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+
+## 0.1.1 - 2026-04-20
+- Upgrade `rubyzip` dependency from `~> 2.0` to `~> 3.0`.
 - Add `allowed_push_host` to gemspec metadata.
 - Update CircleCI config to add changelog check.
 - Rename gemspec from `ooxml_excel.gemspec` to `ooxl.gemspec`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Add `allowed_push_host` to gemspec metadata.
+- Update CircleCI config to add changelog check.
+- Rename gemspec from `ooxml_excel.gemspec` to `ooxl.gemspec`.
+- Lower required Ruby version from `>= 3.3` to `>= 3.2` to match release environment.
 
 ## 0.1.1 - 2026-04-20
 - Upgrade `rubyzip` dependency from `~> 2.0` to `~> 3.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 ## 0.1.1 - 2026-04-20
 - Upgrade `rubyzip` dependency from `~> 2.0` to `~> 3.0`.
-- Add `allowed_push_host` to gemspec metadata.
-- Update CircleCI config to add changelog check.
-- Rename gemspec from `ooxml_excel.gemspec` to `ooxl.gemspec`.
-- Lower required Ruby version from `>= 3.3` to `>= 3.2` to match release environment.
 
 ## 0.1.0 - 2026-03-23
 - Parse Excel spreadsheets (`.xlsx`, `.xlsm`) from file paths, strings, and IO objects.

--- a/lib/ooxl/version.rb
+++ b/lib/ooxl/version.rb
@@ -1,3 +1,3 @@
 class OOXL
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/ooxl.gemspec
+++ b/ooxl.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency 'activesupport'
   spec.add_dependency 'nokogiri', '~> 1'
-  spec.add_dependency 'rubyzip', '~> 2.0'
+  spec.add_dependency 'rubyzip', '~> 3.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
## Summary
With the recent changes made in https://github.com/salsify/salsify_s3_access/pull/60, the pinned dependency `spec.add_dependency 'rubyzip', '~> 2.0'` in this repo, is preventing `salsify_s3_access` to be update in `con-u` with the following error
`````
Fetching gem metadata from https://gems.salsify.com/........
Resolving dependencies...
Could not find compatible versions

Because ooxl >= 0.1.0 depends on rubyzip ~> 2.0
  and ooxl < 0.1.0 depends on rubyzip >= 1.3.0, < 1.4.A,
  rubyzip >= 1.3.0, < 1.4.A OR ~> 2.0 is required.
So, because salsify_s3_access >= 0.10.2 depends on rubyzip >= 3.0
  and Gemfile depends on salsify_s3_access >= 0.10.2,
  version solving has failed.
`````

- Bumps the `rubyzip` dependency from `~> 2.0` to `~> 3.0` (resolves to 3.2.2)
- No code changes required — the APIs used (`Zip::File.open` and `Zip::File.open_buffer`) are unchanged in rubyzip 3.x

cc @salsify/network-core 

🤖 Generated with [Claude Code](https://claude.com/claude-code)